### PR TITLE
Fix/volto version check at least 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,14 @@ Text, Video, HTML, Table
 
 but you could customize your allowed blocks by adding this configuration to your config.js.
 
-If your project runs on Volto < 18.0.0, please set the prop `voltoVersion` into `config.settings['volto-blocks-widget'].voltoVersion`:
-
 ```jsx
 export const settings = {
   ...config.settings,
     'volto-blocks-widget' = {
     allowedBlocks: ['text', 'video', 'html', 'table'],
     showRestricted: false,
-    //voltoVersion: "17"
   },
 };
 ```
+
+The Sidebar rendering strategy (`react-portal` vs native `createPortal`) is chosen automatically based on the installed `@plone/volto` version, no configuration needed.

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,6 @@ export default (config) => {
   config.settings['volto-blocks-widget'] = {
     allowedBlocks: [textBlock, 'image', 'video', 'html', 'table', 'maps'],
     showRestricted: false,
-    //voltoVersion: '17',
   };
 
   config.addonReducers = {

--- a/src/widget/BlocksWidget.jsx
+++ b/src/widget/BlocksWidget.jsx
@@ -11,18 +11,16 @@ import FormFieldWrapper from '@plone/volto/components/manage/Widgets/FormFieldWr
 import { setBlockWidgetSelected } from '../actions';
 import config from '@plone/volto/registry';
 import { useLocation } from 'react-router-dom';
-
-//import voltoPackage from '@plone/volto/package.json';
+import voltoPackage from '@plone/volto/package.json';
 
 import './blocks_widget.css';
+
+const isVoltoVersionAtLeast18 =
+  parseInt(voltoPackage.version.split('.')[0], 10) >= 18;
 
 const BlocksWidget = (props) => {
   const location = useLocation();
   const dispatch = useDispatch();
-
-  const voltoVersion = config.settings['volto-blocks-widget'].voltoVersion + '';
-  const majorVersion = parseInt(voltoVersion.split('.')[0]);
-  const isVoltoVersionAtLeast18 = !isNaN(majorVersion) && majorVersion >= 18;
 
   const { value = {}, id, onChange, required } = props;
   const currentFieldSelected = useSelector(

--- a/src/widget/BlocksWidget.jsx
+++ b/src/widget/BlocksWidget.jsx
@@ -21,7 +21,7 @@ const BlocksWidget = (props) => {
   const dispatch = useDispatch();
 
   const voltoVersion = config.settings['volto-blocks-widget'].voltoVersion + '';
-  const volto18 = voltoVersion.split('.')[0] === '18';
+  const isVoltoVersionAtLeast18 = parseInt(voltoVersion.split('.')[0]) >= 18;
 
   const { value = {}, id, onChange, required } = props;
   const currentFieldSelected = useSelector(
@@ -104,7 +104,7 @@ const BlocksWidget = (props) => {
         </UIForm.Field>
       </div>
 
-      {volto18 ? (
+      {isVoltoVersionAtLeast18 ? (
         <>
           {createPortal(
             <div

--- a/src/widget/BlocksWidget.jsx
+++ b/src/widget/BlocksWidget.jsx
@@ -21,7 +21,8 @@ const BlocksWidget = (props) => {
   const dispatch = useDispatch();
 
   const voltoVersion = config.settings['volto-blocks-widget'].voltoVersion + '';
-  const isVoltoVersionAtLeast18 = parseInt(voltoVersion.split('.')[0]) >= 18;
+  const majorVersion = parseInt(voltoVersion.split('.')[0]);
+  const isVoltoVersionAtLeast18 = !isNaN(majorVersion) && majorVersion >= 18;
 
   const { value = {}, id, onChange, required } = props;
   const currentFieldSelected = useSelector(


### PR DESCRIPTION
## Summary
- Fixes the Volto version check used to pick the Sidebar rendering strategy (`react-portal` vs native `createPortal`), which only kicks in on Volto >= 18.
- The version is now read directly from `@plone/volto/package.json` instead of relying on an integrator-set `voltoVersion` flag in `config.settings['volto-blocks-widget']`. That flag was never populated by default (commented out in `index.js`), so the check always evaluated to `false` regardless of the actual Volto version in use.
- Removed the now-unneeded `voltoVersion` config option and its README documentation — detection is automatic, no configuration required.

## Test plan
- [x] `eslint` on the changed files (no new errors, only pre-existing warnings)
- [ ] Manual check in a Volto >= 18 project: Sidebar renders via `createPortal`
- [ ] Manual check in a Volto < 18 project: Sidebar renders via `react-portal`